### PR TITLE
Fix Prisma client generation

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate --schema=../backend/prisma/schema.prisma"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.1",


### PR DESCRIPTION
## Summary
- generate Prisma client automatically via `postinstall`

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486cd5ccd48321bf6e8efb65ed40bd