### PR TITLE
Fix Prisma client generation

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "node scripts/generate-client.js"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.1",

--- a/apps/frontend/scripts/generate-client.js
+++ b/apps/frontend/scripts/generate-client.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const scriptsDir = __dirname; // apps/frontend/scripts
+const frontendDir = path.dirname(scriptsDir); // apps/frontend
+const schemaSource = path.resolve(frontendDir, '../backend/prisma/schema.prisma');
+const prismaDir = path.join(frontendDir, 'prisma');
+const schemaDest = path.join(prismaDir, 'schema.prisma');
+
+fs.mkdirSync(prismaDir, { recursive: true });
+fs.copyFileSync(schemaSource, schemaDest);
+
+try {
+  execSync(`npx prisma generate --schema=${schemaDest}`, { stdio: 'inherit', cwd: frontendDir });
+} finally {
+  fs.rmSync(schemaDest, { force: true });
+  // optional: remove directory if empty
+  try { fs.rmdirSync(prismaDir); } catch (_) {}
+}


### PR DESCRIPTION
## Summary
- generate Prisma client from backend schema using custom postinstall script

## Testing
- `pnpm lint` *(fails: ENETUNREACH while running frontend lint)*

------
https://chatgpt.com/codex/tasks/task_e_68486cd5ccd48321bf6e8efb65ed40bd