### PR TITLE
fix prisma default db path for local dev

### DIFF
--- a/apps/frontend/src/lib/prisma.ts
+++ b/apps/frontend/src/lib/prisma.ts
@@ -1,4 +1,10 @@
 import { PrismaClient } from '@prisma/client';
+import { join } from 'path';
+
+if (!process.env.DATABASE_URL) {
+  // Fallback to the local SQLite database used by the backend
+  process.env.DATABASE_URL = `file:${join(process.cwd(), '../backend/prisma/dev.db')}`;
+}
 
 // This prevents multiple instances of Prisma Client in development
 const globalForPrisma = global as unknown as {


### PR DESCRIPTION
## Summary
- ensure a default `DATABASE_URL` points to the backend's local sqlite file

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6848772b44c883219d96bb92204f5fca