### PR TITLE
Improve register endpoint and cleanup scripts

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,8 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "postinstall": "prisma generate --schema=../backend/prisma/schema.prisma"
+    "lint": "next lint"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.1",


### PR DESCRIPTION
## Summary
- handle duplicate user errors properly in registration endpoint
- return 201 on successful registration
- remove prisma postinstall script from frontend

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm --filter frontend dev` *(started and served on localhost)*

------
https://chatgpt.com/codex/tasks/task_e_68487b2f6f588321b7950b07d4218f45